### PR TITLE
Updated offsets for 5.13 kernel

### DIFF
--- a/SMI_SM2262.patch
+++ b/SMI_SM2262.patch
@@ -1,8 +1,8 @@
 diff --git a/drivers/pci/pci.c b/drivers/pci/pci.c
-index ce096272f..aa1690822 100644
+index aacf575c15cf..c91c6a2cf674 100644
 --- a/drivers/pci/pci.c
 +++ b/drivers/pci/pci.c
-@@ -4877,7 +4877,7 @@ int pci_bridge_secondary_bus_reset(struct pci_dev *dev)
+@@ -4988,7 +4988,7 @@ int pci_bridge_secondary_bus_reset(struct pci_dev *dev)
  }
  EXPORT_SYMBOL_GPL(pci_bridge_secondary_bus_reset);
  
@@ -12,22 +12,22 @@ index ce096272f..aa1690822 100644
  	struct pci_dev *pdev;
  
 diff --git a/drivers/pci/pci.h b/drivers/pci/pci.h
-index 6d3f75867..41f0ca7d5 100644
+index 93dcdd431072..640d9d26837e 100644
 --- a/drivers/pci/pci.h
 +++ b/drivers/pci/pci.h
-@@ -41,6 +41,7 @@ int pci_mmap_fits(struct pci_dev *pdev, int resno, struct vm_area_struct *vmai,
+@@ -35,6 +35,7 @@ int pci_mmap_fits(struct pci_dev *pdev, int resno, struct vm_area_struct *vmai,
  
  int pci_probe_reset_function(struct pci_dev *dev);
  int pci_bridge_secondary_bus_reset(struct pci_dev *dev);
 +int pci_parent_bus_reset(struct pci_dev *dev, int probe);
  int pci_bus_error_reset(struct pci_dev *dev);
  
- #define PCI_PM_D2_DELAY         200
+ #define PCI_PM_D2_DELAY         200	/* usec; see PCIe r4.0, sec 5.9.1 */
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 812bfc32e..082213788 100644
+index 6d74386eadc2..83c131e44f9d 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3956,6 +3956,29 @@ static int delay_250ms_after_flr(struct pci_dev *dev, int probe)
+@@ -3997,6 +3997,29 @@ static int reset_hinic_vf_dev(struct pci_dev *pdev, int probe)
  	return 0;
  }
  
@@ -57,12 +57,12 @@ index 812bfc32e..082213788 100644
  static const struct pci_dev_reset_methods pci_dev_reset_methods[] = {
  	{ PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_82599_SFP_VF,
  		 reset_intel_82599_sfp_virtfn },
-@@ -3965,6 +3988,8 @@ static const struct pci_dev_reset_methods pci_dev_reset_methods[] = {
- 		reset_ivb_igd },
+@@ -4007,6 +4030,8 @@ static const struct pci_dev_reset_methods pci_dev_reset_methods[] = {
  	{ PCI_VENDOR_ID_SAMSUNG, 0xa804, nvme_disable_and_flr },
  	{ PCI_VENDOR_ID_INTEL, 0x0953, delay_250ms_after_flr },
+ 	{ PCI_VENDOR_ID_INTEL, 0x0a54, delay_250ms_after_flr },
 +	{ 0x126f, 0x2262, prefer_bus_reset },
 +	{ PCI_VENDOR_ID_INTEL, 0xf1a6, prefer_bus_reset },
  	{ PCI_VENDOR_ID_CHELSIO, PCI_ANY_ID,
  		reset_chelsio_generic_dev },
- 	{ 0 }
+ 	{ PCI_VENDOR_ID_HUAWEI, PCI_DEVICE_ID_HINIC_VF,


### PR DESCRIPTION
`pci_dev_reset_methods` changed enough to warrant a new patch. Tested on v5.13.12-arch1 with Intel 760p. 

Latest ssd firmware and QEMU config noted at bugzilla do not resolve the issue in my case, while this kernel patch works.